### PR TITLE
LIBTD-2430: Ingest archive metadata without index file

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from dateutil.parser import parse
 import uuid
 import os
-from boto3.dynamodb.conditions import Key
+from boto3.dynamodb.conditions import Key, Attr
 
 # Environment variables
 collection_category = os.getenv('Collection_Category')
@@ -20,6 +20,7 @@ rights_holder = os.getenv('Rights_Holder')
 region_name = os.getenv('REGION')
 collection_table_name = os.getenv('DYNO_Collection_TABLE')
 archive_table_name = os.getenv('DYNO_Archive_TABLE')
+collectionmap_table_name = os.getenv('DYNO_Collectionmap_TABLE')
 app_img_root_path = os.getenv('APP_IMG_ROOT_PATH')
 noid_scheme = os.getenv('NOID_Scheme')
 noid_naa = os.getenv('NOID_NAA')
@@ -28,24 +29,33 @@ short_url_path = os.getenv('SHORT_URL_PATH')
 api_key = os.getenv('API_KEY')
 api_endpoint = os.getenv('API_ENDPOINT')
  
-dyndb = boto3.resource('dynamodb', region_name=region_name)
-archive_table = dyndb.Table(archive_table_name)
-collection_table = dyndb.Table(collection_table_name)
+try: 
+    dyndb = boto3.resource('dynamodb', region_name=region_name)
+    archive_table = dyndb.Table(archive_table_name)
+    collection_table = dyndb.Table(collection_table_name)
+    collectionmap_table = dyndb.Table(collectionmap_table_name)
 
-single_value_headers = ['Identifier', 'Title', 'Description', 'Rights', 'Thumbnail Path', 'Display_Date', 'Bibliographic Citation', 'Rights Holder']
+except Exception as e:
+    print(f"An error occurred: {str(e)}")
+    raise e
+
+single_value_headers = ['Identifier', 'Title', 'Description', 'Rights', 'Bibliographic Citation',
+                        'Rights Holder', 'Extent']
 multi_value_headers = ['Creator', 'Source', 'Subject', 'Coverage', 'Language', 'Type', 'Is Part Of', 'Medium',
                        'Format', 'Related URL', 'Contributor', 'Tags', 'Provenance', 'Identifier2', 'Reference']
 old_key_list = ['title', 'description', 'creator', 'source', 'circa', 'start_date', 'end_date', 'subject',
                 'belongs_to', 'resource_type', 'location', 'language', 'rights_statement', 'medium',
                 'bibliographic_citation', 'rights_holder', 'format', 'related_url', 'contributor', 'tags', 'parent_collection',
                 'collection_category', 'item_category', 'collection', 'manifest_url', 'thumbnail_path', 'visibility',
-                'create_date', 'modified_date', 'provenance', 'reference', 'repository', 'createdAt', 'updatedAt', 'display_date']
+                'create_date', 'modified_date', 'provenance', 'reference', 'repository', 'createdAt', 'updatedAt',
+                'display_date', 'extent', 'heirarchy_path']
 removable_key_list = ['description', 'creator', 'source', 'circa', 'start_date', 'end_date', 'subject',
                       'belongs_to', 'resource_type', 'location', 'language', 'medium', 'format', 'related_url',
                       'contributor', 'tags', 'rights_statement', 'rights_holder', 'bibliographic_citation',
-                      'provenance', 'reference', 'repository', 'create_date', 'modified_date']
+                      'provenance', 'reference', 'repository', 'create_date', 'modified_date', 'extent']
 new_key_list = [':t', ':d', ':c', ':s', ':ci', ':st', ':e', ':su', ':bt', ':rt', ':l', ':la', ':rs', ':me', ':bc', ':rh', ':f',
-                ':ru', ':ct', ':tg', ':pc', ':cc', ':ic', ':co', ':mu', ':tp', ':v', ':cd', ':m', ':pv', ':rf', ':rp', ':ca', ':ua', ':dd']
+                ':ru', ':ct', ':tg', ':pc', ':cc', ':ic', ':co', ':mu', ':tp', ':v', ':cd', ':m', ':pv', ':rf', ':rp', ':ca',
+                ':ua', ':dd', ':et', ':hp']
 key_list_len = len(old_key_list)
 csv_columns_to_attributes = {'Type': 'resource_type', 'Is Part Of': 'belongs_to', 'Coverage': 'location',
                              'Rights': 'rights_statement', 'Identifier2': 'repository'}
@@ -59,9 +69,11 @@ def lambda_handler(event, context):
         s3 = boto3.client('s3')
         response = s3.get_object(Bucket=bucket, Key=key)
         if 'index.csv' in key:
-            batch_import_archives(response)
-        else:
+            batch_import_archives_with_path(response)
+        elif 'collection_metadata.csv' in key:
             batch_import_collections(response)
+        elif 'archive_metadata.csv' in key:
+            batch_import_archives(response)
     except Exception as e:
         print(f"An error occurred importing {key} from bucket {bucket}: {str(e)}")
         raise e
@@ -79,19 +91,33 @@ def batch_import_collections(response):
         collection_dict = process_csv_metadata(row, 'Collection')
         if not collection_dict:
             continue
-        identifier = collection_dict['identifier'].strip()
-        (result, id_val) = query_by_index(collection_table, 'Identifier', identifier)
-        if result == 'Duplicated':
-            print(f"Error: Duplicated Collection ({identifier}) has been found.")
+        identifier = collection_dict['identifier']
+        items = query_by_index(collection_table, 'Identifier', identifier)
+        if len(items) > 1:
+            print(f"Error: Duplicated Identifier ({identifier}) found in {collection_table}.")
             break
-        elif result == 'Unique':
-            update_item_in_table(collection_table, collection_dict, id_val)
+        elif len(items) == 1:
+            if 'heirarchy_path' in collection_dict:
+                collection_dict['heirarchy_path'].append(items[0]['id'])
+            update_item_in_table(collection_table, collection_dict, items[0]['id'])
         else:
             collection_dict['thumbnail_path'] = app_img_root_path + identifier + "/representative.jpg"
-            create_item_in_table(collection_table, collection_dict, "collection")
+            create_item_in_table(collection_table, collection_dict, 'Collection')
+        if 'heirarchy_path' in collection_dict:
+            update_collection_map(collection_dict['heirarchy_path'][0])
         print(f"Collection {idx+1} ({identifier}) has been imported.")
 
 def batch_import_archives(response):
+
+    df = pd.read_csv(io.BytesIO(response['Body'].read()), na_values='NaN', keep_default_na=False, encoding='utf-8', dtype={'Start Date': str, 'End Date': str})
+
+    for idx, row in df.iterrows():
+        archive_dict = process_csv_metadata(row, 'Archive')
+        if not archive_dict:
+            continue
+        find_and_update(archive_table, archive_dict, 'Archive', idx)
+
+def batch_import_archives_with_path(response):
     csv_lines = response['Body'].read().decode('utf-8').split()
     line_count = 0
     for line in csv_lines:
@@ -110,7 +136,7 @@ def batch_import_archives(response):
                 break
             elif ('identifier' not in archive_dict.keys()) or ('title' not in archive_dict.keys()):
                 continue
-            identifier = archive_dict['identifier'].strip()
+            identifier = archive_dict['identifier']
             matching_parent_paths = [path for path in archive_identifiers if path.endswith(identifier)]
             if len(matching_parent_paths) == 1:
                 parent_collections = matching_parent_paths[0].split('/')
@@ -126,37 +152,50 @@ def batch_import_archives(response):
             archive_dict['parent_collection'] = parent_collection_ids
             if len(parent_collection_ids) > 0:
                 archive_dict['collection'] = parent_collection_ids[0]
+                parent_collection = get_collection(parent_collection_ids[0])
+                archive_dict['heirarchy_path'] = parent_collection['heirarchy_path']
 
-            (result, id_val) = query_by_index(archive_table, 'Identifier', identifier)
-            if result == 'Duplicated':
-                print(f"Error: Duplicated Archive ({identifier}) has been found.")
-                break
-            elif result == 'Unique':
-                update_item_in_table(archive_table, archive_dict, id_val)
-            else:
-                create_item_in_table(archive_table, archive_dict, "archive")
-            print(f"Archive {idx+1} ({identifier}) has been imported.")
+            find_and_update(archive_table, archive_dict, 'Archive', idx)
         line_count += 1
         print(f"{line_count}: Archive Metadata ({csv_path}) has been processed.")
 
+def find_and_update(table, attr_dict, item_type, index):
+    identifier = attr_dict['identifier']
+    items = query_by_index(table, 'Identifier', identifier)
+    if len(items) > 1:
+        print(f"Error: Duplicated Identifier ({identifier}) found in {table}.")
+    elif len(items)== 1:
+        update_item_in_table(table, attr_dict, items[0]['id'])
+    else:
+        create_item_in_table(table, attr_dict, item_type)
+    print(f"Archive {index+1} ({identifier}) has been imported.")
+
 def create_item_in_table(table, attr_dict, item_type):
-    attr_dict['id'] = str(uuid.uuid4())
+    attr_id = str(uuid.uuid4())
+    attr_dict['id'] = attr_id
+    if item_type == 'Collection':
+        if 'heirarchy_path' in attr_dict:
+            attr_dict['heirarchy_path'].append(attr_id)
+        else:
+            attr_dict['heirarchy_path'] = [attr_id]
+
     short_id = mint_NOID()
     if short_id:
         attr_dict['custom_key'] = noid_scheme + noid_naa + "/" + short_id
-    now = datetime.now().strftime("%Y/%m/%d %H:%M:%S")
+    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
     utc_now = utcformat(datetime.now())
     attr_dict['createdAt'] = utc_now
     attr_dict['updatedAt'] = utc_now
     table.put_item(
         Item=attr_dict
     )
-    print('PutItem succeeded:')
+    print(f"PutItem succeeded: {attr_dict['identifier']}")
     if short_id:
         # after NOID is created and item is inserted, update long_url and short_url through API
-        long_url = long_url_path + item_type + "/" + short_id
+        long_url = long_url_path + item_type.lower() + "/" + short_id
         short_url = short_url_path + noid_scheme + noid_naa + "/" + short_id
         update_NOID(long_url, short_url, short_id, now)
+    return attr_id
 
 def update_item_in_table(table, attr_dict, key_val):
     del attr_dict['identifier']
@@ -224,8 +263,8 @@ def process_csv_metadata(data_row, item_type):
 
     attr_dict = {}
     for items in data_row.iteritems():
-        if items[0] and items[1]:
-            set_attribute(attr_dict, items[0].strip(), items[1])
+        if items[0].strip() and str(items[1]).strip():
+            set_attribute(attr_dict, items[0].strip(), str(items[1]).strip())
     if ('identifier' not in attr_dict.keys()) or ('title' not in attr_dict.keys()):
         print(f"Missing required attribute in this row!")
     else:
@@ -258,21 +297,27 @@ def set_attribute(attr_dict, attr, value):
             attr_dict[lower_attr] = True
         else:
             attr_dict[lower_attr] = False
-    elif attr == 'Start Date':
-        attr_dict[lower_attr] = value.strip()
-    elif attr == 'End Date':
-        attr_dict[lower_attr] = value.strip()
+    elif attr == 'Start Date' or attr == 'End Date':
+        print_index_date(attr_dict, value, lower_attr)
+    elif attr == 'Display_Date':
+        attr_dict[lower_attr] = value
+        print_display_date(attr_dict, value, lower_attr)
     elif attr == 'Parent Collection':
-        parent_collection_ids = []
-        parent_identifiers = value.split('~')
-        for identifier in parent_identifiers:
-            (result, id_val) = query_by_index(collection_table, 'Identifier', identifier)
-            if result == 'Unique':
-                parent_collection_ids.append(id_val)
-        if parent_collection_ids:
-            attr_dict[lower_attr] = parent_collection_ids
+        items = query_by_index(collection_table, 'Identifier', value)
+        if len(items) == 1:
+            parent_collection_id = items[0]['id']
+            attr_dict['heirarchy_path'] = items[0]['heirarchy_path']
+            attr_dict[lower_attr] = [parent_collection_id]     
     elif attr == 'Thumbnail Path':
-        attr_dict[lower_attr] = app_img_root_path + value.strip() + "/representative.jpg"
+        attr_dict[lower_attr] = app_img_root_path + value + '/representative.jpg'
+    elif attr == 'Filename':
+        if value.endswith('.pdf') or value.endswith('.jpg'):
+            attr_dict['thumbnail_path'] = app_img_root_path + 'thumbnail/' + value.replace('.pdf', '.jpg')
+            attr_dict['manifest_url'] = app_img_root_path + 'pdf/' + value
+        elif 'video.vt.edu/media' in value:
+            thumbnail = value.split('_')[1]
+            attr_dict['thumbnail_path'] = app_img_root_path + 'thumbnail/' + thumbnail + '.png'
+            attr_dict['manifest_url'] = value
     else:
         if attr in csv_columns_to_attributes:
             lower_attr = csv_columns_to_attributes[attr]
@@ -280,21 +325,28 @@ def set_attribute(attr_dict, attr, value):
         if extracted_value:
             attr_dict[lower_attr] = extracted_value
 
-def print_invalid_date(attr_dict, attr):
+def print_index_date(attr_dict, value, attr):
     try:
-        parsed_date = parse(attr_dict[attr])
-        # dates in Elasticsearch are formatted, e.g. "2015-01-01" or "2015/01/01 12:10:30"
+        parsed_date = parse(value)
+        # dates in Elasticsearch are formatted, e.g. "2015/01/01" or "2015/01/01 12:10:30"
         attr_dict[attr] = parsed_date.strftime("%Y/%m/%d")
-        print(f"Valid date format: {attr_dict[attr]} for {attr}")
     except ValueError:
-        print(f"Error - Unknown date format: {attr_dict[attr]} for {attr}")
-        del attr_dict[attr]
+        print(f"Error - Unknown date format: {value} for {attr}")
     except OverflowError:
-        print(f"Error - Invalid date range: {attr_dict[attr]} for {attr}")
-        del attr_dict[attr]
+        print(f"Error - Invalid date range: {value} for {attr}")
     except:
-        print(f"Error - Unexpect error: {attr_dict[attr]} for {attr}")
-        del attr_dict[attr]
+        print(f"Error - Unexpect error: {value} for {attr}")
+
+def print_display_date(attr_dict, value, attr):
+    try:
+        parsed_date = parse(value)
+        attr_dict[attr] = parsed_date.strftime("%Y-%m-%d")
+    except ValueError:
+        print(f"Unknown date format: {value} for {attr}")
+    except OverflowError:
+        print(f"Error - Invalid date range: {value} for {attr}")
+    except:
+        print(f"Error - Unexpect error: {value} for {attr}")
 
 def query_by_index(table, index_name, value):
     index_key = index_name.lower()
@@ -302,15 +354,21 @@ def query_by_index(table, index_name, value):
         IndexName=index_name,
         KeyConditionExpression=Key(index_key).eq(value)
     )
-    if len(attributes['Items']) > 1:
-        print(f"Duplicated {index_name} ({value}) found in {table}.")
-        return ('Duplicated', None)
-    elif len(attributes['Items']) == 1:
-        attributes = attributes['Items'][0]
-        id_val = attributes['id']
-        return ('Unique', id_val)
-    else:
-        return ('NotFound', None)
+    return attributes['Items']
+
+def get_collection(collection_id):
+    ret_val = None
+    try:
+        response = collection_table.query(
+            KeyConditionExpression=Key('id').eq(collection_id),
+            Limit=1
+        )
+        
+        ret_val = response['Items'][0]
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")
+        raise e
+    return ret_val
 
 def update_attr_dict(attr_dict, update_attr_dict, old_attr, new_attr, attr_names):
     update_exp = ""
@@ -354,36 +412,119 @@ def extract_attribute(header, value):
         return value.split('||')
 
 def create_sub_collections(parent_collections):
-    parent_collection_ids = None
+    parent_id = None
+    heirarchy_list = []
     for idx in range(len(parent_collections)):
         if idx == 0:
-            title = parent_collections[idx]
             identifier = parent_collections[idx]
         else:
-            title = parent_collections[idx]
-            identifier += "_" + parent_collections[idx]
+            identifier += '_' + parent_collections[idx]
 
         collection_dict = {}
-        collection_dict['title'] = title
+        collection_dict['title'] = parent_collections[idx]
         collection_dict['identifier'] = identifier
         set_attributes_from_env(collection_dict, 'Collection')
         collection_dict['visibility'] = True
-        if parent_collection_ids:
-            collection_dict['parent_collection'] = parent_collection_ids
+        if parent_id is not None:
+            collection_dict['parent_collection'] = [parent_id]
+            collection_dict['heirarchy_path'] = heirarchy_list
 
-        (result, id_val) = query_by_index(collection_table, 'Identifier', identifier)
-        if result == 'Duplicated':
-            print(f"Error: Duplicated Collection ({identifier}) has been found.")
+        items = query_by_index(collection_table, 'Identifier', identifier)
+        if len(items) > 1:
+            print(f"Error: Duplicated Identifier ({identifier}) found in {collection_table}.")
             break
-        elif result == 'Unique':
+        elif len(items) == 1:
             print(f"Collection {identifier} exists!")
-            parent_collection_ids = [id_val]
+            parent_id = items[0]['id']
+            heirarchy_list = items[0]['heirarchy_path']
         else:
-            create_item_in_table(collection_table, collection_dict, "collection")
-            print('PutItem succeeded:')
-            print(f"collection {identifier} has been created.")
-            parent_collection_ids = [collection_dict['id']]
-    return parent_collection_ids
+            parent_id = create_item_in_table(collection_table, collection_dict, 'Collection')
+            print(f"Collection PutItem succeeded: {identifier}")
+    
+    if len(heirarchy_list) > 0:
+        update_collection_map(heirarchy_list[0])
+    return [parent_id]
+
+def update_collection_map(top_parent_id):
+    parent = get_collection(top_parent_id)
+    if 'parent_collection' not in parent:
+        map_obj = walk_collection(parent)
+        utc_now = utcformat(datetime.now())
+        if 'collectionmap_id' in parent:
+            collectionmap_table.update_item(
+                Key = {
+                    "id": parent["collectionmap_id"]
+                },
+                AttributeUpdates = {
+                    "map_object": {
+                        "Value": json.dumps(map_obj),
+                        "Action": "PUT"
+                    },
+                    "updatedAt": {
+                        "Value": utc_now,
+                        "Action": "PUT"
+                    }
+                }
+            )
+        else:
+            map_id = str(uuid.uuid4())
+            collectionmap_table.put_item(
+                Item = {
+                    "id": map_id,
+                    "map_object": json.dumps(map_obj),
+                    "collection_id": parent["id"],
+                    "createdAt": utc_now,
+                    "updatedAt": utc_now
+                }
+            )
+
+            collection_table.update_item(
+                Key = {
+                    "id": parent["id"]
+                },
+                AttributeUpdates = {
+                    "collectionmap_id": {
+                        "Value": map_id,
+                        "Action": "PUT"
+                    }
+                }
+            )
+    else:
+        print(f"Error: {parent['identifier']} is not a top level collection")
+
+def get_collection_children(parent_id):
+    scan_kwargs = {
+        'FilterExpression': Attr('parent_collection').contains(parent_id),
+        'ProjectionExpression': "#id, title, custom_key",
+        'ExpressionAttributeNames': {"#id": "id"}
+    }
+    source_table_items = []
+    try:
+        done = False
+        start_key = None
+        while not done:
+            if start_key:
+                scan_kwargs['ExclusiveStartKey'] = start_key
+            response = collection_table.scan(**scan_kwargs)
+            source_table_items.extend(response['Items'])
+            start_key = response.get('LastEvaluatedKey', None)
+            done = start_key is None
+
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")
+        raise e
+    return source_table_items
+
+def walk_collection(parent):
+    custom_key = parent['custom_key'].replace('ark:/53696/', '')
+    map_location = {'id': parent['id'], 'name': parent['title'], 'custom_key': custom_key}
+    children = get_collection_children(parent['id'])
+    if len(children) > 0:
+        map_location['children'] = []
+        for child in children:
+            map_location['children'].append(walk_collection(child))
+    
+    return map_location
 
 def mint_NOID():
     headers = { 'x-api-key': api_key }

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Click *Next* to continue
 | Collection_Category | IAWA |
 | DYNO_Collection_TABLE | collectiontablename |
 | DYNO_Archive_TABLE | archivetablename |
+| DYNO_COLLECTIONMAPTABLE_NAME | collectionmaptablename |
 | NOID_NAA | 53696 |
 | NOID_Scheme | ark:/ |
 | REGION | us-east-1 |
@@ -62,14 +63,14 @@ Above command will package the application and upload it to the S3 bucket you sp
 
 Run the following in your shell to deploy the application to AWS:
 ```bash
-sam deploy --template-file packaged.yaml --stack-name STACKNAME --s3-bucket BUCKETNAME --parameter-overrides 'APPIMGROOTPATH=https://yourURL/ BibliographicCitation="Your sentance" CollectionCategory=collection type DYNOCollectionTABLE=CollectionTableName DYNOArchiveTABLE=ArchiveTableName NOIDNAA=53696 NOIDScheme=ark:/ REGION=us-east-1 RightsHolder="Your sentance" RightsStatement="Your sentance" S3BucketName=S3BucketName LongURLPath=LongURLPath ShortURLPath=ShortURLPath APIKey=APIKey APIEndpoint=APIEndpoint' --capabilities CAPABILITY_IAM --region us-east-1
+sam deploy --template-file packaged.yaml --stack-name STACKNAME --s3-bucket BUCKETNAME --parameter-overrides 'APPIMGROOTPATH=https://yourURL/ BibliographicCitation="Your sentance" CollectionCategory=collection type DYNOCollectionTABLE=CollectionTableName DYNOArchiveTABLE=ArchiveTableName DYNOCollectionmapTABLE=CollectionmapTableName NOIDNAA=53696 NOIDScheme=ark:/ REGION=us-east-1 RightsHolder="Your sentance" RightsStatement="Your sentance" S3BucketName=S3BucketName LongURLPath=LongURLPath ShortURLPath=ShortURLPath APIKey=APIKey APIEndpoint=APIEndpoint' --capabilities CAPABILITY_IAM --region us-east-1
 ```
 
 ### Usage
 * Prepare "collection_metadata.csv" and "index.csv" for Collection and Item ingestion, respectively.
 * Put "collection_metadata.csv" and "index.csv" to the target S3 bucket created after deployment.
 * Create a test event in Lambda function. Set the S3 bucket name as in the previous step. For Collection ingestion, set the object key as "collection_metadata.csv"; for Item ingestion, set the object key as "index.csv."
-* Go to DynamoDB to see the end results in Collection and Archive tables.
+* Go to DynamoDB to see the end results in Collection, Archive and Collectionmap tables.
 
 ### Cleanup
 

--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,8 @@ Parameters:
       Type: String
     DYNOArchiveTABLE:
       Type: String
+    DYNOCollectionmapTABLE:
+      Type: String
     NOIDNAA:
       Type: String
       Default: "53696"
@@ -50,6 +52,8 @@ Resources:
             TableName: !Ref DYNOCollectionTABLE
         - DynamoDBCrudPolicy:
             TableName: !Ref DYNOArchiveTABLE
+        - DynamoDBCrudPolicy:
+            TableName: !Ref DYNOCollectionmapTABLE
         - S3ReadPolicy:
             BucketName: !Ref S3BucketName
       Events:
@@ -68,6 +72,7 @@ Resources:
           Collection_Category: !Ref CollectionCategory
           DYNO_Collection_TABLE: !Ref DYNOCollectionTABLE
           DYNO_Archive_TABLE: !Ref DYNOArchiveTABLE
+          DYNO_Collectionmap_TABLE: !Ref DYNOCollectionmapTABLE
           NOID_NAA: !Ref NOIDNAA
           NOID_Scheme: !Ref NOIDScheme
           REGION: !Ref REGION


### PR DESCRIPTION
Generate records in collectionmap table and add 'heirarchy_path' field into collection and archive records

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2436) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
https://webapps.es.vt.edu/jira/browse/LIBTD-2430

# What does this Pull Request do? (:star:)
This PR adds the ability to ingest archive items without using index.csv file. Also this PR will create/update collectionmap records and create/update heirarchy_path field for collection and archive objects whenever is necessary.

# What's the changes? (:star:)

* create/update heirarchy_path field for collection and archive
* create/update collectionmap records
* updated readme and template.yaml for collectionmap dynamoDB table

# How should this be tested?

* Try to ingest records from hokies repo using 'archive_metadata.csv'
* Try to ingest items from iawa repo using 'index.csv'

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields