### PR TITLE
Ingest Description as multi-valued field instead of single-valued

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -42,13 +42,13 @@ except Exception as e:
 single_value_headers = [
     'Identifier',
     'Title',
-    'Description',
     'Rights',
     'Bibliographic Citation',
     'Rights Holder',
     'Extent']
 multi_value_headers = [
     'Creator',
+    'Description',
     'Source',
     'Subject',
     'Coverage',


### PR DESCRIPTION
**Ingest Description as multi-valued field instead of single-valued.**
* * *

**JIRA Ticket**: () (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Ingest Description as multi-valued field instead of single-valued

# What's the changes? (:star:)
A in-depth description of the changes made by this PR. Technical details and possible side effects.

* Moves Description from `single_value_headers` list to `multi_value_headers` list

# How should this be tested?

* Ingest records with multiple Description values separated by a "double pipe" `||`
* Check that values appear in Dynamo as an array, not a String.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* branch: `multidesc`

# Interested parties
@yinlinchen 

(:star:) Required fields