### PR TITLE
change display_date to be an unformatted String

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -45,7 +45,8 @@ single_value_headers = [
     'Rights',
     'Bibliographic Citation',
     'Rights Holder',
-    'Extent']
+    'Extent',
+    'Display_Date']
 multi_value_headers = [
     'Creator',
     'Description',
@@ -171,7 +172,8 @@ csv_columns_to_attributes = {
     'Is Part Of': 'belongs_to',
     'Coverage': 'location',
     'Rights': 'rights_statement',
-    'Identifier2': 'repository'}
+    'Identifier2': 'repository',
+    'Display_Date': 'display_date'}
 reversed_attribute_names = {
     'source': '#s',
     'location': '#l',
@@ -506,9 +508,6 @@ def set_attribute(attr_dict, attr, value):
             attr_dict[lower_attr] = False
     elif attr == 'Start Date' or attr == 'End Date':
         print_index_date(attr_dict, value, lower_attr)
-    elif attr == 'Display_Date':
-        attr_dict[lower_attr] = value
-        print_display_date(attr_dict, value, lower_attr)
     elif attr == 'Parent Collection':
         items = query_by_index(collection_table, 'Identifier', value)
         if len(items) == 1:
@@ -544,18 +543,6 @@ def print_index_date(attr_dict, value, attr):
         attr_dict[attr] = parsed_date.strftime("%Y/%m/%d")
     except ValueError:
         print(f"Error - Unknown date format: {value} for {attr}")
-    except OverflowError:
-        print(f"Error - Invalid date range: {value} for {attr}")
-    except BaseException:
-        print(f"Error - Unexpect error: {value} for {attr}")
-
-
-def print_display_date(attr_dict, value, attr):
-    try:
-        parsed_date = parse(value)
-        attr_dict[attr] = parsed_date.strftime("%Y-%m-%d")
-    except ValueError:
-        print(f"Unknown date format: {value} for {attr}")
     except OverflowError:
         print(f"Error - Invalid date range: {value} for {attr}")
     except BaseException:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3
-moto[dynamodb2,s3,apigateway]
+moto[dynamodb,s3,apigateway]
 noid-mint
 pandas
 pytest

--- a/tests/unit/test_lambda_handler.py
+++ b/tests/unit/test_lambda_handler.py
@@ -13,7 +13,7 @@ from boto3.dynamodb.conditions import Key, Attr
 from botocore.response import StreamingBody
 from datetime import datetime
 from dateutil.parser import parse
-from moto import mock_dynamodb2
+from moto import mock_dynamodb
 from moto import mock_apigateway
 from requests.models import Response
 from unittest import mock
@@ -23,13 +23,14 @@ from unittest.mock import patch
 single_value_headers = [
     'Identifier',
     'Title',
-    'Description',
     'Rights',
     'Bibliographic Citation',
     'Rights Holder',
-    'Extent']
+    'Extent',
+    'Display_Date']
 multi_value_headers = [
     'Creator',
+    'Description',
     'Source',
     'Subject',
     'Coverage',
@@ -50,7 +51,8 @@ csv_columns_to_attributes = {
     'Is Part Of': 'belongs_to',
     'Coverage': 'location',
     'Rights': 'rights_statement',
-    'Identifier2': 'repository'}
+    'Identifier2': 'repository',
+    'Display_Date': 'display_date'}
 
 test_file = 'test.csv'
 rows = [
@@ -207,19 +209,6 @@ class TestLambda(unittest.TestCase):
         input_value = "January 1st, 9999999999"
         lambda_function.print_index_date(attr_dict, input_value, lower_attr)
 
-    def test_print_display_date(self):
-
-        lower_attr = "Display_Date".lower().replace(' ', '_')
-        input_value = "2022-01-20T15:41:32.945Z"
-        attr_dict = {}
-        attr_dict[lower_attr] = '2022-01-20T15:41:32'
-        lambda_function.print_display_date(attr_dict, input_value, lower_attr)
-        assert attr_dict[lower_attr] == "2022-01-20"
-        input_value = "unknown_format"
-        lambda_function.print_display_date(attr_dict, input_value, lower_attr)
-        input_value = "January 1st, 9999999999"
-        lambda_function.print_display_date(attr_dict, input_value, lower_attr)
-
     def test_rights_statement_with_title(self):
 
         test_value = "Cannery Row, July 28, 1961. Elevation (Ms2008-089)"
@@ -318,7 +307,7 @@ class TestLambda(unittest.TestCase):
         assert attr_dict['end_date'] == "2022/01/20"
 
         lambda_function.set_attribute(
-            attr_dict, 'Display_Date', '2022-01-20T15:41:32.945Z')
+            attr_dict, 'Display_Date', '2022-01-20')
         assert attr_dict['display_date'] == "2022-01-20"
 
         lambda_function.set_attribute(


### PR DESCRIPTION
**Changes display_date to be an unformatted String.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Changes display_date to be an unformatted String. Collection managers would like display date to be unformatted so that they can put different date "types" in

# What's the changes? (:star:)
A in-depth description of the changes made by this PR. Technical details and possible side effects.
* change display_date to be an unformatted String

# How should this be tested?

A description of what steps someone could take to:
* Create a Lambda based on this branch
*  Ingest the attached file into an Amplify backend created from the `v.3.0.0` tag in `dlp-access`
* Make sure that description field is an array in Dynamo

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* branch: `display_date_str`

# Interested parties
@yinlinchen 

(:star:) Required fields